### PR TITLE
Add CI for merge conflicts

### DIFF
--- a/.github/workflows/merge-conflict.yml
+++ b/.github/workflows/merge-conflict.yml
@@ -1,0 +1,14 @@
+name: Check unresolved merge conflict
+
+on: pull_request
+
+jobs:
+  merge_conflict_job:
+    runs-on: ubuntu-latest
+    name: Find merge conflicts
+    steps:
+      # Checkout the source code so there are some files to look at.
+      - uses: actions/checkout@v3
+      # Run the actual merge conflict finder
+      - name: Merge Conflict finder
+        uses: olivernybroe/action-conflict-finder@v4.0


### PR DESCRIPTION
- The CI checks for any unresolved conflicts in the source branch of PR. It fails if there is any, and passes otherwise.